### PR TITLE
Bump `to-regex-range`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "extend-shallow": "^2.0.1",
     "is-number": "^3.0.0",
     "repeat-string": "^1.5.4",
-    "to-regex-range": "^0.2.0"
+    "to-regex-range": "^1.0.2"
   },
   "devDependencies": {
     "gulp-format-md": "^0.1.10",


### PR DESCRIPTION
So that only one version of `is-number` is used.