### PR TITLE
Use "node:" prefixed imports everywhere.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,15 +15,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [8, 10, 12, 14, 16, 18, 20, 22]
+        node: [14.18.0, 14, 16.0.0, 16, 18, 20, 22]
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        exclude:
+          # Node 14 is not available on macos anymore
+          - os: macos-latest
+            node: 14
+          - os: macos-latest
+            node: 14.18.0
 
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const util = require('util');
+const util = require('node:util');
 const toRegexRange = require('to-regex-range');
 
 const isObject = val => val !== null && typeof val === 'object' && !Array.isArray(val);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=8"
+    "node": ">=14.18.0 <15 || >=16"
   },
   "scripts": {
     "lint": "eslint --cache --cache-location node_modules/.cache/.eslintcache --report-unused-disable-directives --ignore-path .gitignore .",
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "gulp-format-md": "^2.0.0",
-    "mocha": "^6.1.1",
+    "mocha": "^10.7.0",
     "nyc": "^15.1.0"
   },
   "keywords": [

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('node:assert');
 const fill = require('..');
 
 describe('error handling', () => {

--- a/test/invalid.js
+++ b/test/invalid.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('node:assert');
 const fill = require('..');
 
 describe('invalid ranges', () => {

--- a/test/matching.js
+++ b/test/matching.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('node:assert');
 const fill = require('..');
 
 const toRegex = (...args) => new RegExp(`^(${fill(...args)})$`);

--- a/test/options.js
+++ b/test/options.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('node:assert');
 const exact = require('./support/exact');
 const fill = require('..');
 

--- a/test/padding.js
+++ b/test/padding.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert').strict;
+const assert = require('node:assert').strict;
 const fill = require('..');
 
 describe('padding: numbers', () => {

--- a/test/support/exact.js
+++ b/test/support/exact.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const assert = require('assert');
-const util = require('util');
+const assert = require('node:assert');
+const util = require('node:util');
 
 module.exports = (actual, expected) => {
   assert(Array.isArray(actual));

--- a/test/verify-matches.js
+++ b/test/verify-matches.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const assert = require('assert');
+const assert = require('node:assert');
 const expand = require('./support/expand');
 const fill = require('..');
 let count = 0;


### PR DESCRIPTION
Update minimum nodejs version to the ones where this feature was introduced, and update CI accordingly.

Also bumped the mocha version to the latest one, as that one is still compatible with the now bumped nodejs version.

---

Using "node:" prefixed imports enable the use of this library in runtimes other than nodejs that provide node compatibility layer by checking the "node:" prefix in package names (notably, `workerd`). The cost for that is the bump of the minimum nodejs version to ">=14.18.0 <15 || >=16".

The other alternative for "using in other runtimes" would be to remove the one use of util.inspect(), but since even these new versions are EOL, and compatibility layer for inspect() is present, I imagine bumping the minimum node version is the better option.

Or, there's also the option of trying to require node:util and fallback to "util", with "util" being used through an optional peer dependency to [util](https://www.npmjs.com/package/util).